### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Testing.pm
+++ b/lib/Testing.pm
@@ -1,4 +1,4 @@
-module Testing:ver<0.0.1>:auth<cpan:DCONWAY>;
+unit module Testing:ver<0.0.1>:auth<cpan:DCONWAY>;
 
 # Track how many tests to report...
 my $test_count = 0;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
